### PR TITLE
Make CI fail on SwiftLint warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,4 @@ jobs:
       run: brew install swiftlint
     
     - name: Run SwiftLint
-      run: swiftlint lint --reporter github-actions-logging
-      continue-on-error: true
+      run: swiftlint lint --strict --reporter github-actions-logging


### PR DESCRIPTION
## Summary
- Removed `continue-on-error: true` from SwiftLint CI step
- Added `--strict` flag to SwiftLint command

## Details
The `--strict` flag makes SwiftLint treat warnings as errors, causing it to exit with a non-zero status code when any violations are found. This ensures that the CI will fail if there are any SwiftLint violations, maintaining code quality standards.

## Test plan
- [x] CI configuration updated
- [ ] CI should now fail if SwiftLint detects any warnings
- [ ] All existing code should pass SwiftLint checks (already fixed in #7)

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)