### PR TITLE
Add DMG release workflow with version injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,31 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app
     
+    - name: Extract version from tag
+      id: get_version
+      run: |
+        # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION"
+    
     - name: Build Release
       run: |
         xcodebuild -project VoiceLogger.xcodeproj \
           -scheme VoiceLogger \
           -configuration Release \
           -destination 'platform=macOS' \
+          -derivedDataPath build \
           clean build \
           CODE_SIGN_IDENTITY="" \
-          CODE_SIGNING_REQUIRED=NO
+          CODE_SIGNING_REQUIRED=NO \
+          MARKETING_VERSION=${{ steps.get_version.outputs.VERSION }}
     
     - name: Create DMG
       run: |
         # Create a temporary directory for DMG contents
         mkdir -p dmg-contents
-        cp -R build/Release/VoiceLogger.app dmg-contents/VoiceLogger.app
+        cp -R build/Build/Products/Release/VoiceLogger.app dmg-contents/VoiceLogger.app
         
         # Create Applications symlink
         ln -s /Applications dmg-contents/Applications
@@ -47,9 +57,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: VoiceLogger ${{ github.ref }}
+        release_name: VoiceLogger ${{ steps.get_version.outputs.VERSION }}
         body: |
-          VoiceLogger release ${{ github.ref }}
+          VoiceLogger release ${{ steps.get_version.outputs.VERSION }}
           
           ## Changes
           - See commit history for changes

--- a/VoiceLogger/AppDelegate.swift
+++ b/VoiceLogger/AppDelegate.swift
@@ -208,6 +208,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSUserNotifi
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Settings...", action: #selector(openSettings), keyEquivalent: ","))
         menu.addItem(NSMenuItem.separator())
+        
+        // Add version info
+        let versionString = getVersionString()
+        let versionItem = NSMenuItem(title: versionString, action: nil, keyEquivalent: "")
+        versionItem.isEnabled = false
+        menu.addItem(versionItem)
+        
+        menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit VoiceLogger", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
         
         statusItem.menu = menu
@@ -391,6 +399,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSUserNotifi
     
     @objc private func openLogFile() {
         FileManager.shared.openCurrentLogFile()
+    }
+    
+    private func getVersionString() -> String {
+        let bundle = Bundle.main
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
+        return "Version \(version) (\(build))"
     }
     
     // MARK: - NSMenuDelegate


### PR DESCRIPTION
## Summary
- Updated release workflow to inject version numbers from git tags
- Added version info display in the app menu
- Fixed build output paths in DMG creation

## Changes

### Release Workflow
- Extract version from git tag (e.g., v1.2.3 → 1.2.3)
- Inject version into build using MARKETING_VERSION parameter
- Use correct derived data path for build artifacts
- Clean up release naming to use version instead of full ref

### App Changes
- Added version display in menu bar dropdown
- Shows "Version X.X.X (build)" format
- Version is disabled menu item for information only

## How it works
1. Push a tag like `v1.0.1`
2. GitHub Actions triggers the release workflow
3. Version 1.0.1 is extracted and injected into the app
4. DMG is created and attached to the GitHub release
5. Users see version info in the app menu

## Test plan
- [x] Build succeeds with version injection
- [x] Version appears correctly in app menu
- [ ] Release workflow creates DMG on tag push
- [ ] DMG is attached to GitHub release
- [ ] App shows injected version number

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)