### PR TITLE
Change release workflow to trigger on release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
   build-release:
@@ -11,15 +10,18 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.release.tag_name }}
     
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app
     
-    - name: Extract version from tag
+    - name: Extract version from release
       id: get_version
       run: |
-        # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
-        VERSION=${GITHUB_REF#refs/tags/v}
+        # Extract version from release tag (e.g., v1.2.3 -> 1.2.3)
+        VERSION=${{ github.event.release.tag_name }}
+        VERSION=${VERSION#v}
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         echo "Version: $VERSION"
     
@@ -50,25 +52,11 @@ jobs:
           -ov -format UDZO \
           VoiceLogger.dmg
     
-    - name: Create Release
+    - name: Upload Release Asset
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release create "${{ github.ref_name }}" \
-          --title "VoiceLogger ${{ steps.get_version.outputs.VERSION }}" \
-          --notes "VoiceLogger release ${{ steps.get_version.outputs.VERSION }}
-        
-        ## Changes
-        - See commit history for changes
-        
-        ## Installation
-        1. Download VoiceLogger.dmg
-        2. Open the DMG file
-        3. Drag VoiceLogger to Applications folder
-        4. Launch VoiceLogger from Applications
-        
-        ## Permissions Required
-        - Microphone access
-        - Speech recognition
-        - Accessibility (for global shortcuts)" \
-          VoiceLogger.dmg
+        # Upload DMG to the existing release
+        gh release upload "${{ github.event.release.tag_name }}" \
+          VoiceLogger.dmg \
+          --clobber


### PR DESCRIPTION
## Summary
- Change workflow trigger from tag push to release creation
- Upload DMG to existing release instead of creating a new one

## What was wrong
The previous fix still had the workflow creating releases, but the actual requirement is:
1. User manually creates a GitHub Release
2. This triggers the workflow
3. Workflow builds the DMG and uploads it to that release

## Changes
- Changed trigger from `on: push: tags:` to `on: release: types: [created]`
- Use `github.event.release.tag_name` to get the release tag
- Changed from `gh release create` to `gh release upload`
- Checkout the specific release tag to ensure we build the correct version

## How it works now
1. Create a release on GitHub (e.g., v1.0.0)
2. Workflow automatically triggers
3. Builds DMG with the version number
4. Uploads DMG to the release

This properly handles the GitHub Release → Build → Upload flow.

Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)