### PR TITLE
Add Makefile for building the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.PHONY: build debug release clean test run help
+
+BUILD_DIR = build
+DERIVED_DATA = $(BUILD_DIR)/DerivedData
+
+# Default target
+all: build
+
+# Build (Debug configuration)
+build:
+	xcodebuild -project VoiceLogger.xcodeproj -scheme VoiceLogger -configuration Debug \
+		-derivedDataPath $(DERIVED_DATA) \
+		CONFIGURATION_BUILD_DIR=$(PWD)/$(BUILD_DIR)/Debug \
+		build
+
+# Debug build (alias)
+debug: build
+
+# Release build
+release:
+	xcodebuild -project VoiceLogger.xcodeproj -scheme VoiceLogger -configuration Release \
+		-derivedDataPath $(DERIVED_DATA) \
+		CONFIGURATION_BUILD_DIR=$(PWD)/$(BUILD_DIR)/Release \
+		build
+
+# Clean build artifacts
+clean:
+	xcodebuild clean -project VoiceLogger.xcodeproj -scheme VoiceLogger
+	rm -rf $(BUILD_DIR)/
+
+# Run tests
+test:
+	xcodebuild test -project VoiceLogger.xcodeproj -scheme VoiceLogger -destination 'platform=macOS'
+
+# Run the app (Debug)
+run: build
+	open $(BUILD_DIR)/Debug/VoiceLogger.app
+
+# Run the app (Release)
+run-release: release
+	open $(BUILD_DIR)/Release/VoiceLogger.app
+
+# Open project in Xcode
+xcode:
+	open VoiceLogger.xcodeproj
+
+# Show help
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build debug configuration (default)"
+	@echo "  debug       - Build debug configuration"
+	@echo "  release     - Build release configuration"
+	@echo "  clean       - Clean build artifacts"
+	@echo "  test        - Run unit tests"
+	@echo "  run         - Build and run debug app"
+	@echo "  run-release - Build and run release app"
+	@echo "  xcode       - Open project in Xcode"
+	@echo "  help        - Show this help"


### PR DESCRIPTION
## Summary
- Add Makefile to simplify project build process
- Support Debug/Release configurations with output to `build/` directory
- Include targets for building, running, testing, and cleaning

## Available targets
- `make` / `make build` - Debug build
- `make release` - Release build
- `make run` / `make run-release` - Build and run
- `make test` - Run unit tests
- `make clean` - Clean build artifacts
- `make help` - Show help

## Test plan
- [x] `make build` succeeds
- [x] `make clean` succeeds
- [x] Build output appears in `build/Debug/`